### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: (Prod) Build and deploy
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/dag-hammarskjold-library/gstream3/security/code-scanning/1](https://github.com/dag-hammarskjold-library/gstream3/security/code-scanning/1)

To resolve the issue, we will add a `permissions` block at the root level of the workflow. This ensures that all jobs within the workflow inherit the specified minimal permissions. Since the workflow does not use the `GITHUB_TOKEN` for any write operations, we will set `contents: read` as the minimal starting point. This will ensure that the workflow adheres to the principle of least privilege.

Proposed changes:
1. Add the `permissions` block at the root (after the `name` field) with `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
